### PR TITLE
Docker container for stuga2020

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:12.18
+
+# Create app directory
+WORKDIR /usr/src/stugan
+
+# Install dependencies
+COPY package*.json ./
+RUN npm install
+
+# Stuga web app sources
+COPY . ./
+
+EXPOSE 8080
+CMD [ "npm", "start" ]
+
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,6 @@ RUN npm install
 COPY . ./
 
 EXPOSE 8080
-CMD [ "npm", "start" ]
+CMD [ "npm", "run", "start-docker" ]
 
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
     "xterm-webfont": "^2.0.0"
   },
   "scripts": {
-    "start": "webpack-dev-server --open --host 0.0.0.0",
+    "start": "webpack-dev-server --open",
+    "start-docker" : "webpack-dev-server --open --host 0.0.0.0",
     "build": "webpack --config webpack.config.js"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "xterm-webfont": "^2.0.0"
   },
   "scripts": {
-    "start": "webpack-dev-server --open",
+    "start": "webpack-dev-server --open --host 0.0.0.0",
     "build": "webpack --config webpack.config.js"
   },
   "devDependencies": {


### PR DESCRIPTION
Here is a Dockerfile for stuga2020. It exposes port 8080. 
I needed to host it on ip 0.0.0.0, because localhost gets unreachable in the docker context. 

Build:

`docker build -t stuga:1.0 .`

Run:

`docker run --rm -d -p 8080:8080 stuga:1.0`

Visit localhost 8080!